### PR TITLE
feat(metadata/sqlite): implement update/get/list_entity method

### DIFF
--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -5,6 +5,9 @@ pub enum Error {
    #[error("found {0} already exist in database")]
    ColumnAlreadyExist(String),
 
+   #[error("column {1} not found from table {0}")]
+   ColumnNotFound(String, String),
+
    #[error("sqlx error")]
    SqlxError(#[from] sqlx::Error),
 

--- a/src/database/metadata/sqlite/entity.rs
+++ b/src/database/metadata/sqlite/entity.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use sqlx::FromRow;
 
 use crate::database::error::Error;
 use crate::database::metadata::{DBStore, Entity};
@@ -10,7 +11,7 @@ use super::DB;
 #[async_trait]
 impl DBStore for DB {
     async fn create_entity(&self, name: &str, description: &str) -> Result<i64> {
-        let res = sqlx::query("INSERT INTO ENTITY (name, description) VALUES (?, ?)")
+        let res = sqlx::query("INSERT INTO entity (name, description) VALUES (?, ?)")
                 .bind(name)
                 .bind(description)
                 .execute(&self.pool)
@@ -31,21 +32,55 @@ impl DBStore for DB {
     }
 
     async fn update_entity(&self, id: i64, new_description: &str) -> Result<()> {
-        todo!()
+        let rows_affected = sqlx::query("UPDATE entity SET description = ? WHERE id = ?")
+                .bind(new_description)
+                .bind(id)
+                .execute(&self.pool)
+                .await?
+                .rows_affected();
+
+        if rows_affected != 1 {
+            Err(Error::ColumnNotFound("entity".to_owned(), id.to_string()))
+        } else {
+            Ok(())
+        }
     }
 
     async fn get_entity(&self, name: &str) -> Result<Option<Entity>> {
-        todo!()
+        let res: Option<Entity> = sqlx::query_as("SELECT * FROM entity WHERE name = ?")
+                .bind(name)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(res) 
     }
 
     async fn list_entity(&self, ids: Vec<i64>) -> Result<Vec<Entity>> {
-        todo!()
+        let query_str = format!("SELECT * FROM entity WHERE id in (?{})", ", ?".repeat(ids.len()-1));
+        let mut query = sqlx::query(&query_str);
+
+        for id in ids {
+            query = query.bind(id);
+        }
+
+        let res = query
+                .fetch_all(&self.pool)
+                .await?
+                .iter()
+                .map(|row| {
+                    Entity::from_row(row)
+                })
+                .collect::<std::result::Result<Vec<Entity>, sqlx::Error>>();
+
+        match res {
+            Ok(res) => Ok(res),
+            Err(e) => Err(e.into()),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use sqlx::SqlitePool;
+    use sqlx::{SqlitePool, pool};
 
     use crate::database::error::Error;
 
@@ -69,5 +104,63 @@ mod tests {
             Some(Error::ColumnAlreadyExist(name)) => name == "user",
             _ => false,
         }, true);
+    }
+
+    #[sqlx::test]
+    fn get_entity(pool: SqlitePool) {
+        let db = prepare_db(pool).await;
+
+        let id = db.create_entity("name", "description").await.unwrap();
+
+        let entity = db.get_entity("name").await.unwrap().unwrap();
+        assert_eq!(entity.id, id);
+        assert_eq!(entity.name, "name");
+        assert_eq!(entity.description, "description");
+
+        let res = db.get_entity("no_exist").await.unwrap();
+        assert!(res.is_none());
+    }
+
+    #[sqlx::test]
+    fn update_entity(pool: SqlitePool) {
+        let db = prepare_db(pool).await;
+
+        let id = db.create_entity("name", "description").await.unwrap();
+
+        assert!(db.update_entity(id, "new_description").await.is_ok());
+
+        let entity = db.get_entity("name").await.unwrap().unwrap();
+        assert_eq!(entity.id, id);
+        assert_eq!(entity.name, "name");
+        assert_eq!(entity.description, "new_description");
+
+        assert_eq!(db.update_entity(id+1, "new_description").await.is_err_and(|e| match e{
+            Error::ColumnNotFound(table, id) => table == "entity" && id == "2",
+            _ => false,
+        }), true);
+    }
+
+    #[sqlx::test]
+    fn list_entity(pool: SqlitePool) {
+        let db = prepare_db(pool).await;
+
+        let entitys = db.list_entity(vec![1,2,3]).await.unwrap();
+        assert_eq!(entitys.len(), 0);
+
+        assert!(db.create_entity("name", "description").await.is_ok());
+        let entitys = db.list_entity(vec![1,2,3]).await.unwrap();
+        assert_eq!(entitys.len(), 1);
+
+        assert!(db.create_entity("name2", "description").await.is_ok());
+        let entitys = db.list_entity(vec![1,2,3]).await.unwrap();
+        assert_eq!(entitys.len(), 2);
+
+        assert!(db.create_entity("name3", "description").await.is_ok());
+        let entitys = db.list_entity(vec![1,2,3]).await.unwrap();
+        assert_eq!(entitys.len(), 3);
+
+        assert!(db.create_entity("name4", "description").await.is_ok());
+        let entitys = db.list_entity(vec![1,2,3]).await.unwrap();
+        assert_eq!(entitys.len(), 3);
     }
 }

--- a/src/database/metadata/types.rs
+++ b/src/database/metadata/types.rs
@@ -1,11 +1,12 @@
 use chrono::DateTime;
 use chrono::Utc;
 
+#[derive(sqlx::FromRow)]
 pub struct Entity {
-    id: i64,
-    name: String,
-    description: String,
+    pub id: i64,
+    pub name: String,
+    pub description: String,
 
-    create_time: DateTime<Utc>,
-    modify_time: DateTime<Utc>,
+    pub create_time: DateTime<Utc>,
+    pub modify_time: DateTime<Utc>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
+#![feature(is_some_and)]
+
 mod database;


### PR DESCRIPTION
this PR does:
1. implement `get_entity` for SQLite metadata store.
2. implement `list_entity` for SQLite metadata store.
3. implement `update_entity` for SQLie metadata store.

relate issues: https://github.com/lianxmfor/feastore/issues/1
